### PR TITLE
AI-Fix Look for # Summary in Changes before opening a PR in sweagent/run/hooks/open_pr.py

### DIFF
--- a/sweagent/run/hooks/open_pr.py
+++ b/sweagent/run/hooks/open_pr.py
@@ -198,6 +198,12 @@ def format_trajectory_markdown(trajectory: list[dict[str, str]], char_limit: int
     """
     suffix_text = "\n"
 
-    complete_response = trajectory[-1]['response']
+    complete_response = ""
+    for element in trajectory:
+        response = element['response']
+        index = response.find("# Summary of Changes:")
+        if index != -1:
+            complete_response = response[index:]
+            break
 
     return complete_response + suffix_text


### PR DESCRIPTION
<think>
Okay, I need to make sure the changes I made to the format_trajectory_markdown function are correct. Let me review the code again.

The original code was taking the last element's response, but now it loops through each element in the trajectory. For each response, it checks if "# Summary of Changes:" is present. If found, it captures everything from that point onward and breaks the loop. If none are found, complete_response remains an empty string.

I should check if the indentation is correct. The loop starts at line 201, which is indented under the function. The for loop and the if statement are properly indented. The variables are correctly assigned, and the break statement exits the loop once the summary is found.

I don't see any duplicate lines or syntax errors. The code should now correctly extract the summary from the first occurrence in the trajectory. The rest of the function, like handling the suffix_text, should remain unaffected.

I think the changes are correct. Now, I can submit the modified file.
</think>

# Summary of Changes:
- Modified the `format_trajectory_markdown` function to search for the `# Summary of Changes:` string in each element of the trajectory list.
- The function now iterates through the trajectory and returns the portion of the response starting from the first occurrence of the summary string.
- This ensures that the PR body includes the correct summary section as specified in the issue.




This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close issue [#1].